### PR TITLE
Allow `css_class` to have blank value.

### DIFF
--- a/django_bootstrap_calendar/models.py
+++ b/django_bootstrap_calendar/models.py
@@ -21,7 +21,7 @@ class CalendarEvent(models.Model):
     )
     title = models.CharField(max_length=255, verbose_name=_('Title'))
     url = models.URLField(verbose_name=_('URL'), null=True, blank=True)
-    css_class = models.CharField(max_length=20, verbose_name=_('CSS Class'),
+    css_class = models.CharField(blank=True, max_length=20, verbose_name=_('CSS Class'),
                                  choices=CSS_CLASS_CHOICES)
     start = models.DateTimeField(verbose_name=_('Start Date'))
     end = models.DateTimeField(verbose_name=_('End Date'), null=True,


### PR DESCRIPTION
Currently the default value for the `css_class` field (name `Normal`)
has the value of a blank string. To allow the value to be used
`blank=True` must be set.

In the current state a validation error is thrown if the option is selected.

I am using Django 1.8.4 for reference.